### PR TITLE
Upgrade Node.js minimum version to 22 and update CI matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ export default [
         },
       ],
       "no-unused-vars": "off", // Turn off base rule in favor of TypeScript version
+      "no-undef": "off", // TypeScript's own checker handles undefined variables in .ts files
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/app.js",
   "packageManager": "pnpm@10.32.1",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.106.0",
@@ -20,7 +20,7 @@
     "test": "We don't do testing here",
     "start": "node dist/app.js",
     "dev": "pnpm build && pnpm start",
-    "lint": "pnpm eslint src/ --ext .ts"
+    "lint": "pnpm eslint src/"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Updates the project's Node.js version requirements to 22.0.0 as the minimum supported version, aligns the CI/CD pipeline to test against Node 22.x and 24.x, and makes minor ESLint configuration adjustments.

## Key Changes
- **package.json**: Bumped `engines.node` from `>=18.0.0` to `>=22.0.0`
- **package.json**: Simplified `lint` script to remove the `--ext .ts` flag (ESLint now handles TypeScript files by default in modern versions)
- **.github/workflows/node.js.yml**: Updated CI matrix from `[18.x, 20.x, 22.x]` to `[22.x, 24.x]` to test against currently supported Node versions
- **eslint.config.mjs**: Disabled the `no-undef` ESLint rule in favor of TypeScript's built-in undefined variable checking for `.ts` files

## Implementation Details
These changes reflect a modernization of the project's tooling baseline. The Node.js 22 minimum aligns with LTS support timelines, and the ESLint adjustments leverage TypeScript's superior type checking for undefined variables rather than relying on ESLint's simpler heuristic. The CI matrix now focuses on actively maintained Node versions.

https://claude.ai/code/session_017xayoMLABWDztcJE7LvH7j